### PR TITLE
Add offline rule analysis and export tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-# Ignore TIA Portal PublicAPI DLLs copied during build
-src/Agent.OpennessBridge/lib/*.dll
+__pycache__/
+reports/
+exports/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # Aco-tiaV1
 
-Bootstrap commit for Codex tasks.
+Minimal offline analysis MVP for PLC programs.
+
+## Analyze
+
+Run static analysis on a JSON description of blocks:
+
+```bash
+python tools/analyze.py examples/sample_program.json
+```
+
+Use `--lang ro` for Romanian messages. The script prints rule
+violations and may generate a report:
+
+```bash
+python tools/analyze.py examples/sample_program.json --report
+```
+
+Reports are written to `reports/` as HTML and optionally PDF.
+
+## Export network
+
+To export a specific network to SCL text and copy it to the clipboard:
+
+```bash
+python tools/analyze.py examples/sample_program.json --export OB1 1
+```
+
+The file is written under `exports/`.

--- a/examples/sample_program.json
+++ b/examples/sample_program.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "OB1",
+    "networks": [
+      ["A := 1", "A := 0", "TON T1 IN:=TRUE", "MOVE target"],
+      ["OUT := TRUE"]
+    ],
+    "meta": {"scan_time": true}
+  }
+]

--- a/src/rule_engine/__init__.py
+++ b/src/rule_engine/__init__.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import List, Dict, Any
+
+
+@dataclass
+class Location:
+    block: str
+    network: int
+    index: int
+
+
+@dataclass
+class RuleResult:
+    code: str
+    severity: str
+    message: str
+    location: Location
+
+
+# Type aliases for clarity
+Instruction = str
+Network = List[Instruction]
+Block = Dict[str, Any]

--- a/src/rule_engine/engine.py
+++ b/src/rule_engine/engine.py
@@ -1,0 +1,11 @@
+from typing import List
+from . import Block, RuleResult
+from .rules import RULES
+
+
+def analyze(blocks: List[Block], lang: str = "en") -> List[RuleResult]:
+    results: List[RuleResult] = []
+    for block in blocks:
+        for rule in RULES:
+            results.extend(rule(block, lang))
+    return results

--- a/src/rule_engine/report.py
+++ b/src/rule_engine/report.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from . import RuleResult
+
+
+def generate_html(results: List[RuleResult], path: Path, lang: str = "en") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+    for r in results:
+        loc = f"{r.location.block}/{r.location.network}/{r.location.index}"
+        rows.append(
+            f"<tr><td>{r.code}</td><td>{r.severity}</td><td>{r.message}</td><td>{loc}</td></tr>"
+        )
+    html = (
+        "<html><head><meta charset='utf-8'></head><body>"
+        "<h1>Analysis Report</h1>"
+        "<table border='1'><tr><th>Rule</th><th>Severity</th><th>Message</th><th>Location</th></tr>"
+        + "".join(rows)
+        + "</table></body></html>"
+    )
+    path.write_text(html, encoding="utf-8")
+    return path
+
+
+def generate_pdf(html_path: Path, pdf_path: Path) -> None:
+    try:
+        import pdfkit
+
+        pdf_path.parent.mkdir(parents=True, exist_ok=True)
+        pdfkit.from_file(str(html_path), str(pdf_path))
+    except Exception:
+        # pdf generation is optional; ignore if it fails
+        pass

--- a/src/rule_engine/rules.py
+++ b/src/rule_engine/rules.py
@@ -1,0 +1,132 @@
+import re
+from typing import List
+from . import Block, RuleResult, Location
+
+
+MESSAGES = {
+    "R1": {
+        "en": "Multiple assignments to same variable",
+        "ro": "Atribuiri multiple pentru aceeași variabilă",
+    },
+    "R2": {
+        "en": "TON/TOF without conditional IN",
+        "ro": "TON/TOF fără IN condiționat",
+    },
+    "R3": {
+        "en": "Constant signal assignment",
+        "ro": "Semnal constant asignat",
+    },
+    "R4": {
+        "en": "Movement/output without interlock",
+        "ro": "Mişcare/iesire fără interlock",
+    },
+    "R5": {
+        "en": "OB1 contains scan time warning",
+        "ro": "OB1 conţine avertisment de timp de scanare",
+    },
+}
+
+
+class Rule:
+    def __init__(self, code: str, severity: str, func):
+        self.code = code
+        self.severity = severity
+        self.func = func
+
+    def __call__(self, block: Block, lang: str) -> List[RuleResult]:
+        return self.func(block, lang)
+
+
+# Rule implementations
+
+def _r1(block: Block, lang: str) -> List[RuleResult]:
+    results: List[RuleResult] = []
+    for net_idx, network in enumerate(block.get("networks", []), start=1):
+        seen = {}
+        for idx, instr in enumerate(network, start=1):
+            m = re.match(r"(\w+)\s*:=", instr)
+            if m:
+                var = m.group(1)
+                if var in seen:
+                    results.append(
+                        RuleResult(
+                            "R1",
+                            "warning",
+                            MESSAGES["R1"][lang],
+                            Location(block["name"], net_idx, idx),
+                        )
+                    )
+                else:
+                    seen[var] = idx
+    return results
+
+
+def _r2(block: Block, lang: str) -> List[RuleResult]:
+    results: List[RuleResult] = []
+    for net_idx, network in enumerate(block.get("networks", []), start=1):
+        for idx, instr in enumerate(network, start=1):
+            if ("TON" in instr or "TOF" in instr) and re.search(r"IN:=\s*(TRUE|1)", instr, re.I):
+                results.append(
+                    RuleResult(
+                        "R2",
+                        "warning",
+                        MESSAGES["R2"][lang],
+                        Location(block["name"], net_idx, idx),
+                    )
+                )
+    return results
+
+
+def _r3(block: Block, lang: str) -> List[RuleResult]:
+    results: List[RuleResult] = []
+    for net_idx, network in enumerate(block.get("networks", []), start=1):
+        for idx, instr in enumerate(network, start=1):
+            if re.search(r":=\s*(TRUE|1)\b", instr, re.I):
+                results.append(
+                    RuleResult(
+                        "R3",
+                        "info",
+                        MESSAGES["R3"][lang],
+                        Location(block["name"], net_idx, idx),
+                    )
+                )
+    return results
+
+
+def _r4(block: Block, lang: str) -> List[RuleResult]:
+    results: List[RuleResult] = []
+    for net_idx, network in enumerate(block.get("networks", []), start=1):
+        for idx, instr in enumerate(network, start=1):
+            if re.match(r"(MOVE|OUT)", instr) and "IF" not in instr.upper():
+                results.append(
+                    RuleResult(
+                        "R4",
+                        "warning",
+                        MESSAGES["R4"][lang],
+                        Location(block["name"], net_idx, idx),
+                    )
+                )
+    return results
+
+
+def _r5(block: Block, lang: str) -> List[RuleResult]:
+    results: List[RuleResult] = []
+    if block.get("name") == "OB1" and block.get("meta", {}).get("scan_time"):
+        results.append(
+            RuleResult(
+                "R5",
+                "info",
+                MESSAGES["R5"][lang],
+                Location(block["name"], 0, 0),
+            )
+        )
+    return results
+
+
+RULES = [
+    Rule("R1", "warning", _r1),
+    Rule("R2", "warning", _r2),
+    Rule("R3", "info", _r3),
+    Rule("R4", "warning", _r4),
+    Rule("R5", "info", _r5),
+]

--- a/tools/analyze.py
+++ b/tools/analyze.py
@@ -1,0 +1,72 @@
+import argparse
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from rule_engine.engine import analyze
+from rule_engine.report import generate_html, generate_pdf
+
+
+def load_blocks(path: Path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def export_network(blocks, block_name: str, network_index: int, export_dir: Path):
+    export_dir.mkdir(parents=True, exist_ok=True)
+    for b in blocks:
+        if b.get("name") == block_name:
+            try:
+                network = b["networks"][network_index - 1]
+            except (KeyError, IndexError):
+                return None
+            text = "\n".join(network)
+            out_path = export_dir / f"{block_name}_N{network_index}.scl"
+            out_path.write_text(text, encoding="utf-8")
+            try:
+                import pyperclip
+
+                pyperclip.copy(text)
+            except Exception:
+                pass
+            return out_path
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run rule analysis")
+    parser.add_argument("input", help="Path to program JSON")
+    parser.add_argument("--lang", default="en", choices=["en", "ro"])
+    parser.add_argument("--report", action="store_true", help="Generate HTML/PDF report")
+    parser.add_argument(
+        "--export", nargs=2, metavar=("BLOCK", "NETWORK"), help="Export network as SCL"
+    )
+    args = parser.parse_args()
+
+    blocks = load_blocks(Path(args.input))
+    results = analyze(blocks, lang=args.lang)
+    for r in results:
+        loc = f"{r.location.block}/{r.location.network}/{r.location.index}"
+        print(f"{r.code} {r.severity} {r.message} @ {loc}")
+
+    if args.report:
+        reports_dir = Path("reports")
+        html_path = reports_dir / "report.html"
+        pdf_path = reports_dir / "report.pdf"
+        generate_html(results, html_path, lang=args.lang)
+        generate_pdf(html_path, pdf_path)
+        print(f"Report written to {html_path}")
+
+    if args.export:
+        block, net = args.export
+        exported = export_network(blocks, block, int(net), Path("exports"))
+        if exported:
+            print(f"Network exported to {exported}")
+        else:
+            print("Failed to export network")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple rule engine with five initial PLC analysis rules
- include CLI for running analysis, generating reports, and exporting networks
- document workflow for analyzing JSON blocks and exporting code

## Testing
- `python tools/analyze.py examples/sample_program.json`
- `python tools/analyze.py examples/sample_program.json --report`
- `python tools/analyze.py examples/sample_program.json --export OB1 1`


------
https://chatgpt.com/codex/tasks/task_e_6898df5043a48321b568ed5502ca8929