### PR TITLE
feat: add PDF import and indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 reports/
 exports/
+**/bin/
+**/obj/

--- a/src/Agent.PdfImporter/Agent.PdfImporter.csproj
+++ b/src/Agent.PdfImporter/Agent.PdfImporter.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3405.78" />
+    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+  </ItemGroup>
+
+</Project>

--- a/src/Agent.PdfImporter/App.xaml
+++ b/src/Agent.PdfImporter/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="Agent.PdfImporter.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/src/Agent.PdfImporter/App.xaml.cs
+++ b/src/Agent.PdfImporter/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace Agent.PdfImporter
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/src/Agent.PdfImporter/MainWindow.xaml
+++ b/src/Agent.PdfImporter/MainWindow.xaml
@@ -1,0 +1,24 @@
+<Window x:Class="Agent.PdfImporter.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        Title="PDF Importer" Height="600" Width="800">
+    <DockPanel>
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="Import PDF..." Click="ImportPdf_Click"/>
+            </MenuItem>
+        </Menu>
+        <StatusBar DockPanel.Dock="Bottom">
+            <TextBlock x:Name="StatusText" />
+        </StatusBar>
+        <DockPanel>
+            <StackPanel DockPanel.Dock="Left" Width="200">
+                <TextBox x:Name="SearchBox" Margin="5" KeyDown="SearchBox_KeyDown"/>
+                <ListBox x:Name="PageList" Margin="5" SelectionChanged="PageList_SelectionChanged"/>
+                <TreeView x:Name="IndexTree" Margin="5" />
+            </StackPanel>
+            <wv2:WebView2 x:Name="PdfViewer"/>
+        </DockPanel>
+    </DockPanel>
+</Window>

--- a/src/Agent.PdfImporter/MainWindow.xaml.cs
+++ b/src/Agent.PdfImporter/MainWindow.xaml.cs
@@ -1,0 +1,133 @@
+using Microsoft.Web.WebView2.Wpf;
+using Microsoft.Win32;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using UglyToad.PdfPig;
+
+namespace Agent.PdfImporter
+{
+    public partial class MainWindow : Window
+    {
+        private string? _pdfPath;
+        private PdfIndex? _index;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void ImportPdf_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFileDialog { Filter = "PDF files (*.pdf)|*.pdf" };
+            if (dlg.ShowDialog() == true)
+            {
+                LoadPdf(dlg.FileName);
+            }
+        }
+
+        private void LoadPdf(string path)
+        {
+            _pdfPath = path;
+            PdfViewer.Source = new Uri("file:///" + path);
+            StatusText.Text = System.IO.Path.GetFileName(path);
+            BuildIndex(path);
+            PageList.ItemsSource = Enumerable.Range(1, _index?.Pages.Count ?? 0).ToList();
+            BuildTree();
+        }
+
+        private void BuildIndex(string path)
+        {
+            var blockRegex = new Regex(@"^(?:Block\s+)?(OB|FB|FC|DB)\s*\d+", RegexOptions.Multiline);
+            var networkRegex = new Regex(@"^(?:Network|Retea)\s*\d+", RegexOptions.Multiline);
+            var index = new PdfIndex { PdfPath = path };
+            string? currentBlock = null;
+            using (var doc = PdfDocument.Open(path))
+            {
+                foreach (var page in doc.GetPages())
+                {
+                    var text = page.Text;
+                    var info = new PdfPageInfo { PageNumber = page.Number, Text = text, ImageOnly = string.IsNullOrWhiteSpace(text) };
+                    foreach (Match m in blockRegex.Matches(text))
+                    {
+                        currentBlock = m.Value.Trim();
+                        var blockEntry = index.Blocks.FirstOrDefault(b => b.Name == currentBlock);
+                        if (blockEntry == null)
+                        {
+                            blockEntry = new BlockEntry { Name = currentBlock };
+                            index.Blocks.Add(blockEntry);
+                        }
+                        info.Blocks.Add(currentBlock);
+                    }
+                    foreach (Match m in networkRegex.Matches(text))
+                    {
+                        var name = m.Value.Trim();
+                        info.Networks.Add(name);
+                        if (currentBlock != null)
+                        {
+                            var blockEntry = index.Blocks.First(b => b.Name == currentBlock);
+                            blockEntry.Networks.Add(new NetworkEntry { Name = name, Page = page.Number });
+                        }
+                    }
+                    index.Pages.Add(info);
+                }
+            }
+            _index = index;
+            var indexPath = Path.Combine(Path.GetDirectoryName(path)!, Path.GetFileName(path) + ".index.json");
+            File.WriteAllText(indexPath, JsonSerializer.Serialize(index, new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        private void BuildTree()
+        {
+            if (_index == null) return;
+            IndexTree.Items.Clear();
+            var root = new TreeViewItem { Header = $"PDF {System.IO.Path.GetFileName(_index.PdfPath)}" };
+            var blocksNode = new TreeViewItem { Header = "Blocks" };
+            root.Items.Add(blocksNode);
+            foreach (var block in _index.Blocks)
+            {
+                var blockItem = new TreeViewItem { Header = block.Name };
+                blocksNode.Items.Add(blockItem);
+                foreach (var net in block.Networks)
+                {
+                    var netItem = new TreeViewItem { Header = net.Name, Tag = net.Page };
+                    blockItem.Items.Add(netItem);
+                }
+            }
+            IndexTree.SelectedItemChanged += IndexTree_SelectedItemChanged;
+            IndexTree.Items.Add(root);
+            root.IsExpanded = true;
+        }
+
+        private void IndexTree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            if (IndexTree.SelectedItem is TreeViewItem item && item.Tag is int page && _pdfPath != null)
+            {
+                PdfViewer.Source = new Uri($"file:///{_pdfPath}#page={page}");
+                PageList.SelectedItem = page;
+            }
+        }
+
+        private void PageList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (PageList.SelectedItem is int page && _pdfPath != null)
+            {
+                PdfViewer.Source = new Uri($"file:///{_pdfPath}#page={page}");
+            }
+        }
+
+        private void SearchBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter && _pdfPath != null)
+            {
+                var term = SearchBox.Text;
+                PdfViewer.Source = new Uri($"file:///{_pdfPath}#search={Uri.EscapeDataString(term)}");
+            }
+        }
+    }
+}

--- a/src/Agent.PdfImporter/PdfIndex.cs
+++ b/src/Agent.PdfImporter/PdfIndex.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Agent.PdfImporter
+{
+    public class PdfIndex
+    {
+        public string PdfPath { get; set; } = string.Empty;
+        public List<PdfPageInfo> Pages { get; set; } = new();
+        public List<BlockEntry> Blocks { get; set; } = new();
+    }
+
+    public class PdfPageInfo
+    {
+        public int PageNumber { get; set; }
+        public string Text { get; set; } = string.Empty;
+        public bool ImageOnly { get; set; }
+        public List<string> Blocks { get; set; } = new();
+        public List<string> Networks { get; set; } = new();
+    }
+
+    public class BlockEntry
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<NetworkEntry> Networks { get; set; } = new();
+    }
+
+    public class NetworkEntry
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Page { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add WPF PDF importer using WebView2 for rendering
- parse PDF with PdfPig and build block/network index
- save index next to PDFs and enable search navigation

## Testing
- `dotnet build src/Agent.PdfImporter/Agent.PdfImporter.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689b7bf2c64c832196e4389c5d43e38d