### PR TITLE
Add chat panel with local LLM integration

### DIFF
--- a/configs/appsettings.json
+++ b/configs/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "LLM": {
+    "Url": "http://localhost:1234/v1/chat/completions",
+    "Model": "default-model",
+    "MaxTokens": 512
+  }
+}

--- a/src/Agent.PdfImporter/Agent.PdfImporter.csproj
+++ b/src/Agent.PdfImporter/Agent.PdfImporter.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3405.78" />
     <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Agent.PdfImporter/Chat/ChatControl.xaml
+++ b/src/Agent.PdfImporter/Chat/ChatControl.xaml
@@ -1,0 +1,37 @@
+<UserControl x:Class="Agent.PdfImporter.Chat.ChatControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="0">
+            <ItemsControl x:Name="Messages">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Margin="4">
+                            <TextBlock FontWeight="Bold" Text="{Binding Role}" />
+                            <TextBlock TextWrapping="Wrap" Text="{Binding Content}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Stretch" Margin="4">
+            <Button Content="Explică rețeaua curentă" Click="QuickSuggestion_Click" Margin="2" />
+            <Button Content="Ce face TON-ul?" Click="QuickSuggestion_Click" Margin="2" />
+            <Button Content="Există dublu coil pe Q0.0?" Click="QuickSuggestion_Click" Margin="2" />
+            <Button Content="Ce să testez aici?" Click="QuickSuggestion_Click" Margin="2" />
+        </StackPanel>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="4">
+            <TextBox x:Name="Input" Width="400" />
+            <Button Content="Trimite" Click="Send_Click" Margin="4,0,0,0" />
+            <Button Content="Export" Click="Export_Click" Margin="4,0,0,0" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/Agent.PdfImporter/Chat/ChatControl.xaml.cs
+++ b/src/Agent.PdfImporter/Chat/ChatControl.xaml.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Agent.PdfImporter.Chat
+{
+    public partial class ChatControl : UserControl
+    {
+        private readonly ChatService _chat;
+        public string OcrText { get; set; } = string.Empty;
+        public List<string> Hints { get; set; } = new();
+
+        public ChatControl()
+        {
+            InitializeComponent();
+
+            var configRoot = new ConfigurationBuilder()
+                .AddJsonFile(Path.Combine("..", "..", "configs", "appsettings.json"), optional: true)
+                .Build();
+            var llmConfig = configRoot.GetSection("LLM").Get<LlmConfig>() ?? new LlmConfig();
+            _chat = new ChatService(new LlmClient(llmConfig), new ContextBuilder());
+
+            Messages.ItemsSource = _chat.History;
+        }
+
+        private async void Send_Click(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(OcrText))
+            {
+                _chat.History.Add(new ChatMessage { Role = ChatRole.System, Content = "No OCR data. Please re-scan." });
+                Messages.Items.Refresh();
+                return;
+            }
+
+            var question = Input.Text;
+            Input.Clear();
+            await _chat.AskAsync(question, OcrText, Hints);
+            Messages.Items.Refresh();
+        }
+
+        private async void QuickSuggestion_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn)
+            {
+                Input.Text = btn.Content.ToString();
+                Send_Click(sender, e);
+            }
+        }
+
+        private void Export_Click(object sender, RoutedEventArgs e)
+        {
+            var path = Path.Combine(Path.GetTempPath(), "chat.md");
+            _chat.ExportMarkdown(path);
+            MessageBox.Show($"Exported to {path}");
+        }
+    }
+}

--- a/src/Agent.PdfImporter/Chat/ChatMessage.cs
+++ b/src/Agent.PdfImporter/Chat/ChatMessage.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Agent.PdfImporter.Chat
+{
+    public enum ChatRole
+    {
+        System,
+        User,
+        Assistant
+    }
+
+    public class ChatMessage
+    {
+        public ChatRole Role { get; set; }
+        public string Content { get; set; } = string.Empty;
+        public List<string> Thumbnails { get; set; } = new();
+    }
+}

--- a/src/Agent.PdfImporter/Chat/ChatService.cs
+++ b/src/Agent.PdfImporter/Chat/ChatService.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Agent.PdfImporter.Chat
+{
+    public class ChatService
+    {
+        private readonly LlmClient _llm;
+        private readonly ContextBuilder _contextBuilder;
+        private readonly List<ChatMessage> _history = new();
+
+        public IReadOnlyList<ChatMessage> History => _history;
+
+        public ChatService(LlmClient llm, ContextBuilder contextBuilder)
+        {
+            _llm = llm;
+            _contextBuilder = contextBuilder;
+        }
+
+        public async Task<ChatMessage> AskAsync(string question, string ocrText, IEnumerable<string> hints)
+        {
+            var prompt = _contextBuilder.BuildPrompt(ocrText, hints, question);
+            _history.Add(new ChatMessage { Role = ChatRole.User, Content = question });
+            var completion = await _llm.GetCompletionAsync(prompt);
+            var reply = new ChatMessage { Role = ChatRole.Assistant, Content = completion };
+            _history.Add(reply);
+            return reply;
+        }
+
+        public void ExportMarkdown(string path)
+        {
+            var sb = new StringBuilder();
+            foreach (var msg in _history)
+            {
+                sb.AppendLine($"### {msg.Role}");
+                sb.AppendLine(msg.Content);
+                sb.AppendLine();
+            }
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        public void ExportHtml(string path)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("<html><body>");
+            foreach (var msg in _history)
+            {
+                sb.AppendLine($"<h3>{msg.Role}</h3>");
+                sb.AppendLine($"<p>{System.Net.WebUtility.HtmlEncode(msg.Content)}</p>");
+            }
+            sb.AppendLine("</body></html>");
+            File.WriteAllText(path, sb.ToString());
+        }
+    }
+}

--- a/src/Agent.PdfImporter/Chat/ContextBuilder.cs
+++ b/src/Agent.PdfImporter/Chat/ContextBuilder.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Agent.PdfImporter.Chat
+{
+    public class ContextBuilder
+    {
+        private readonly int _maxOcrChars;
+
+        public ContextBuilder(int maxOcrChars = 2000)
+        {
+            _maxOcrChars = maxOcrChars;
+        }
+
+        public string BuildPrompt(string ocrText, IEnumerable<string> hints, string question)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("You are a helpful assistant for PLC ladder logic.");
+            if (!string.IsNullOrWhiteSpace(ocrText))
+            {
+                var truncated = ocrText.Length > _maxOcrChars ? ocrText[.._maxOcrChars] : ocrText;
+                sb.AppendLine("OCR Text:");
+                sb.AppendLine(truncated);
+            }
+            if (hints != null && hints.Any())
+            {
+                sb.AppendLine("Hints:");
+                foreach (var hint in hints)
+                {
+                    sb.AppendLine("- " + hint);
+                }
+            }
+            sb.AppendLine("Question:");
+            sb.AppendLine(question);
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Agent.PdfImporter/Chat/LlmClient.cs
+++ b/src/Agent.PdfImporter/Chat/LlmClient.cs
@@ -1,0 +1,32 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace Agent.PdfImporter.Chat
+{
+    public class LlmClient
+    {
+        private readonly HttpClient _httpClient = new();
+        private readonly LlmConfig _config;
+
+        public LlmClient(LlmConfig config)
+        {
+            _config = config;
+        }
+
+        public async Task<string> GetCompletionAsync(string prompt)
+        {
+            var request = new
+            {
+                model = _config.Model,
+                prompt,
+                max_tokens = _config.MaxTokens
+            };
+
+            var response = await _httpClient.PostAsJsonAsync(_config.Url, request);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            return json;
+        }
+    }
+}

--- a/src/Agent.PdfImporter/Chat/LlmConfig.cs
+++ b/src/Agent.PdfImporter/Chat/LlmConfig.cs
@@ -1,0 +1,9 @@
+namespace Agent.PdfImporter.Chat
+{
+    public class LlmConfig
+    {
+        public string Url { get; set; } = "";
+        public string Model { get; set; } = "";
+        public int MaxTokens { get; set; } = 512;
+    }
+}

--- a/src/Agent.PdfImporter/MainWindow.xaml
+++ b/src/Agent.PdfImporter/MainWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        xmlns:local="clr-namespace:Agent.PdfImporter.Chat"
         Title="PDF Importer" Height="600" Width="800">
     <DockPanel>
         <Menu DockPanel.Dock="Top">
@@ -19,6 +20,7 @@
                 <TreeView x:Name="IndexTree" Margin="5" />
             </StackPanel>
             <wv2:WebView2 x:Name="PdfViewer"/>
+            <local:ChatControl DockPanel.Dock="Right" Width="300" />
         </DockPanel>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- add chat user control with conversation history and quick suggestion buttons
- integrate local LLM via configurable endpoint and context builder
- allow markdown export and fallback message when OCR data missing

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b8b97aa748321989e120c41122481