### PR TITLE
Add Windows stock management build artifact workflow

### DIFF
--- a/apps/gestiune-stoc-win/.github/workflows/ci.yml
+++ b/apps/gestiune-stoc-win/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Build gestiune-stoc-win
+
+on:
+  push:
+    paths:
+      - 'apps/gestiune-stoc-win/**'
+  pull_request:
+    paths:
+      - 'apps/gestiune-stoc-win/**'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run build
+        shell: pwsh
+        run: |
+          cd apps/gestiune-stoc-win
+          ./Build.ps1
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gestiune-stoc-win
+          path: apps/gestiune-stoc-win/gestiune-stoc-win.zip

--- a/apps/gestiune-stoc-win/.gitignore
+++ b/apps/gestiune-stoc-win/.gitignore
@@ -1,0 +1,2 @@
+out/
+gestiune-stoc-win.zip

--- a/apps/gestiune-stoc-win/Build.ps1
+++ b/apps/gestiune-stoc-win/Build.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+$OutDir = Join-Path $PSScriptRoot 'out'
+if (-not (Test-Path $OutDir)) {
+    throw "Output directory '$OutDir' not found."
+}
+
+$ZipPath = Join-Path $PSScriptRoot 'gestiune-stoc-win.zip'
+if (Test-Path $ZipPath) {
+    Remove-Item $ZipPath
+}
+
+Compress-Archive -Path (Join-Path $OutDir '*') -DestinationPath $ZipPath -Force


### PR DESCRIPTION
## Summary
- add Build.ps1 to package `out` contents into `gestiune-stoc-win.zip`
- create CI workflow to run build and upload the ZIP as an artifact
- ignore generated output and archive files

## Testing
- `pwsh -File apps/gestiune-stoc-win/Build.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_689ce8c85d3c832190449ab27aacede7)